### PR TITLE
2.0.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,7 +154,11 @@ async function main() {
   console.log(separatorLine());
 
   console.log(`Source from ${templateRepo} repository used for clone below.`);
-  const cloneResult = childProcessModule.spawnSync("git", ["clone", templateRepo, projectName], { stdio: "inherit" });
+  const cloneResult = childProcessModule.spawnSync(
+    "git",
+    ["clone", "-b", packageVersion, templateRepo, projectName], // There must be a branch in decentapp-template repo that matches the version of this package.
+    { stdio: "inherit" }
+  );
   if (cloneResult.status !== 0) throw new ExpectedError("Failed to clone repository.");
 
   console.log(`Removing .git folders...`); // Because it's a brand new project with no ties to the past.

--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
   "name": "create-decent-app",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "index.js",
   "keywords": [
     "webai",
     "webllm",
-    "ollama",
     "llm",
     "local-first",
     "offline-first"


### PR DESCRIPTION
CDA will now retrieve a pinned version of the project template rather than the latest.

It's using a new 2.0.1 version that updates dependencies and call new Github actions for deployment.